### PR TITLE
dont default fpm version, and adjust task

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-php_fpm_version: "5.5.9+dfsg-1ubuntu4.4"
+php_fpm_version: ""
 php_fpm_upload_max_filesize: "10M"
 php_fpm_post_max_size: "10M"
 php_fpm_env:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install PHP-FPM
-  apt: pkg=php5-fpm={{ php_fpm_version }} state=present
+  apt: pkg=php5-fpm{% if php_fpm_version %}={{ php_fpm_version }}{% endif %} state=present
 
 - name: Configure PHP
   template: src=php.ini.j2 dest=/etc/php5/fpm/php.ini


### PR DESCRIPTION
To avoid issues like this https://github.com/azavea/ansible-php-fpm/issues/4, default the fpm version to the one in the apt-cache, and only add in version if its specified directly by the play

FIXES https://github.com/azavea/ansible-php-fpm/issues/4